### PR TITLE
remove a regulation which allow shulker spawning in endCities

### DIFF
--- a/server/world/carpet.conf
+++ b/server/world/carpet.conf
@@ -1,5 +1,4 @@
 fastRedstoneDust true
-shulkerSpawningInEndCities true
 commandLog true
 commandPlayer true
 defaultLoggers mobcaps,tps


### PR DESCRIPTION
删除潜影贝能在末地城自然生成，mojang已经给了潜影贝量产方式了